### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Or install it yourself as:
 
     $ gem install rails-forward_compatible_controller_tests
 
-At the appropriate spot in your `test_helper.rb`, `spec_helper.rb`, or similar file add the following line:
+At the appropriate spot in your `test_helper.rb`, `rails_helper.rb`, or similar file add the following line:
 
 ```ruby
 require 'rails/forward_compatible_controller_tests'


### PR DESCRIPTION
Requiring `rails/forward_compatible_controller_tests` in the `spec_helper.rb` will fail in the RSpec context as the Rails application is not yet initialized. Loading the gem via `rails_helper.rb` after the framework was initialized is the way to go.